### PR TITLE
Use first part of celery task name as queue name

### DIFF
--- a/bureaucrat/channelwrapper.py
+++ b/bureaucrat/channelwrapper.py
@@ -82,8 +82,9 @@ class ChannelWrapper(object):
                 "taskset": None,
                 "chord": None
             }
-            self._ch.basic_publish(exchange='celery',
-                                   routing_key="celery",
+            name = participant.split(".", 1)[0]
+            self._ch.basic_publish(exchange=name,
+                                   routing_key=name,
                                    body=json.dumps(celery_msg),
                                    properties=pika.BasicProperties(
                                        delivery_mode=2,


### PR DESCRIPTION
To enable running different tasks per worker, each worker should use a separate queue.
Run the celery workers with "-Q <queuename>" to enable them to receive the relevant tasks.
